### PR TITLE
String keys

### DIFF
--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -14,10 +14,10 @@ defmodule ExQueb do
     if q do
       filters = Map.to_list(q)
       |> Enum.filter(&(not elem(&1,1) in ["", nil]))
-      |> Enum.map(fn(item) ->
-        case is_atom(elem(item,0)) do
-          true -> {Atom.to_string(elem(item, 0)), elem(item, 1)}
-          false -> { elem(item, 0), elem(item, 1)}
+      |> Enum.map(fn({key, value}) ->
+        case is_atom(key) do
+          true -> {Atom.to_string(key), value}
+          false -> { key, value }
         end
       end)
 

--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -14,7 +14,12 @@ defmodule ExQueb do
     if q do
       filters = Map.to_list(q)
       |> Enum.filter(&(not elem(&1,1) in ["", nil]))
-      |> Enum.map(&({Atom.to_string(elem(&1, 0)), elem(&1, 1)}))
+      |> Enum.map(fn(item) ->
+        case is_atom(elem(item,0)) do
+          true -> {Atom.to_string(elem(item, 0)), elem(item, 1)}
+          false -> { elem(item, 0), elem(item, 1)}
+        end
+      end)
 
       query
       |> ExQueb.StringFilters.string_filters(filters)

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
-  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [], []},
+  "earmark": {:hex, :earmark, "0.2.1", "ba6d26ceb16106d069b289df66751734802777a3cbb6787026dd800ffeb850f3", [:mix], []},
   "ecto": {:hex, :ecto, "2.1.1", "fa8bdb14be9992b777036e20f183b8c4300cc012a0fae748529ff89b5423f2dd", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
-  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
+  "ex_doc": {:hex, :ex_doc, "0.11.5", "0dc51cb84f8312162a2313d6c71573a9afa332333d8a332bb12540861b9834db", [:mix], [{:earmark, "~> 0.1.17 or ~> 0.2", [hex: :earmark, optional: true]}]},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -46,6 +46,12 @@ defmodule ExQuebTest do
     assert_equal ExQueb.filter(Test.Model, %{q: %{name_contains: "Test"}}), expected
   end
 
+  test "filters can be strings" do
+    expected = where(Test.Model, [m], like(fragment("LOWER(?)", m.name), ^"%test%"))
+    params =  %{q: %{"name_contains" => "Test"}}
+    assert_equal ExQueb.filter(Test.Model,params), expected
+  end
+
   test "handles different default primary key" do
     query = from n in Test.Noid, preload: []
     expected = from n in Test.Noid, order_by: [desc: n.name]


### PR DESCRIPTION
If a query param that contains string keys is passed in the current implementation breaks. Phoenix by default passes strings into the controller as keys so it make sense to allow this.