### PR TITLE
Compatibility with Ecto 3

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,1 @@
+[inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]]

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,5 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-
 # Over ride defaults by adding these into your config.exs file.
 # config :ex_queb, filter_param: :q 

--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -79,19 +79,20 @@ defmodule ExQueb do
   end
 
   defp _build_date_filter(query, fld, value, :gte) do
-    where(query, [q], fragment("? >= ?", field(q, ^fld), type(^value, Ecto.DateTime)))
+    where(query, [q], fragment("? >= ?", field(q, ^fld), type(^value, DateTime)))
   end
 
   defp _build_date_filter(query, fld, value, :lte) do
-    where(query, [q], fragment("? <= ?", field(q, ^fld), type(^value, Ecto.DateTime)))
+    where(query, [q], fragment("? <= ?", field(q, ^fld), type(^value, DateTime)))
   end
 
   defp cast_date_time(value) do
-    {:ok, date} = Ecto.Date.cast(value)
+    value
+    # {:ok, date} = Ecto.Date.cast(value)
 
-    date
-    |> Ecto.DateTime.from_date()
-    |> Ecto.DateTime.to_string()
+    # date
+    # |> Ecto.DateTime.from_date()
+    # |> Ecto.DateTime.to_string()
   end
 
   @doc """
@@ -165,7 +166,7 @@ defmodule ExQueb do
 
   defp get_default_order_by_field(query) do
     case query do
-      %{from: {_, mod}} ->
+      %Ecto.Query{from: %Ecto.Query.FromExpr{source: {_, mod}}} ->
         case mod.__schema__(:primary_key) do
           [name | _] -> name
           _ -> mod.__schema__(:fields) |> List.first()

--- a/lib/string_filters.ex
+++ b/lib/string_filters.ex
@@ -24,10 +24,10 @@ defmodule ExQueb.StringFilters do
 
   defp build_string_filters(builder, filters, type) do
     filters
-    |> Enum.filter(& String.match?(elem(&1,0), ~r/_#{type}$/))
-    |> Enum.map(& {String.replace(elem(&1, 0), "_#{type}", ""), elem(&1, 1)})
-    |> Enum.reduce(builder, fn({k,v}, acc) ->
-      fld = String.to_atom k
+    |> Enum.filter(&String.match?(elem(&1, 0), ~r/_#{type}$/))
+    |> Enum.map(&{String.replace(elem(&1, 0), "_#{type}", ""), elem(&1, 1)})
+    |> Enum.reduce(builder, fn {k, v}, acc ->
+      fld = String.to_atom(k)
       _build_string_filter(acc, fld, v, type)
     end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,12 +1,12 @@
 defmodule ExQueb.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.1.0"
 
   def project do
     [app: :ex_queb,
      version: @version,
-     elixir: "~> 1.2",
+     elixir: "~> 1.7",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      docs: [extras: ["README.md"], main: "ExQueb"],
@@ -25,7 +25,7 @@ defmodule ExQueb.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 2.0"},
+      {:ecto, "~> 3.0"},
       {:ex_doc, "~> 0.18.0", only: :dev},
       {:earmark, "~> 1.1", only: :dev},
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -4,19 +4,20 @@ defmodule ExQueb.Mixfile do
   @version "1.1.0"
 
   def project do
-    [app: :ex_queb,
-     version: @version,
-     elixir: "~> 1.7",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     docs: [extras: ["README.md"], main: "ExQueb"],
-     package: package(),
-     name: "ExQueb",
-     deps: deps(),
-     description: """
-     Ecto Filter Query Builder
-     """
-   ]
+    [
+      app: :ex_queb,
+      version: @version,
+      elixir: "~> 1.7",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      docs: [extras: ["README.md"], main: "ExQueb"],
+      package: package(),
+      name: "ExQueb",
+      deps: deps(),
+      description: """
+      Ecto Filter Query Builder
+      """
+    ]
   end
 
   def application do
@@ -27,14 +28,16 @@ defmodule ExQueb.Mixfile do
     [
       {:ecto, "~> 3.0"},
       {:ex_doc, "~> 0.18.0", only: :dev},
-      {:earmark, "~> 1.1", only: :dev},
+      {:earmark, "~> 1.1", only: :dev}
     ]
   end
 
   defp package do
-    [ maintainers: ["Stephen Pallen"],
+    [
+      maintainers: ["Stephen Pallen"],
       licenses: ["MIT"],
-      links: %{ "Github" => "https://github.com/E-MetroTel/ex_queb" },
-      files: ~w(lib README.md mix.exs LICENSE)]
+      links: %{"Github" => "https://github.com/E-MetroTel/ex_queb"},
+      files: ~w(lib README.md mix.exs LICENSE)
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
-  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
+  "decimal": {:hex, :decimal, "1.5.0", "b0433a36d0e2430e3d50291b1c65f53c37d56f83665b43d79963684865beab68", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "2.1.1", "fa8bdb14be9992b777036e20f183b8c4300cc012a0fae748529ff89b5423f2dd", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
+  "ecto": {:hex, :ecto, "3.0.2", "9d06ece60e2fc9b7593e74ede23747424ef32390016baca85cea3f4b84081c52", [:mix], [{:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
 }

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -1,8 +1,9 @@
 defmodule Test.Model do
   use Ecto.Schema
+
   schema "models" do
-    field :name, :string
-    field :age, :integer
+    field(:name, :string)
+    field(:age, :integer)
 
     timestamps()
   end
@@ -12,7 +13,7 @@ defmodule Test.Noid do
   use Ecto.Schema
   @primary_key {:name, :string, []}
   schema "noids" do
-    field :description, :string
+    field(:description, :string)
 
     timestamps()
   end
@@ -22,9 +23,9 @@ defmodule Test.Noprimary do
   use Ecto.Schema
   @primary_key false
   schema "noprimarys" do
-    field :index, :integer
-    field :name, :string
-    field :description, :string
+    field(:index, :integer)
+    field(:name, :string)
+    field(:description, :string)
 
     timestamps()
   end
@@ -37,67 +38,73 @@ defmodule ExQuebTest do
   require Logger
 
   test "no filter" do
-    assert_equal ExQueb.filter(Test.Model, %{}), Test.Model
+    assert_equal(ExQueb.filter(Test.Model, %{}), Test.Model)
   end
 
   # %{blog_id_eq: "1", inserted_at_gte: nil, inserted_at_lte: nil, name_contains: nil, updated_at_gte: nil, updated_at_lte: nil}
   test "filters single field" do
     expected = where(Test.Model, [m], like(fragment("LOWER(?)", m.name), ^"%test%"))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_contains: "Test"}}), expected
+    assert_equal(ExQueb.filter(Test.Model, %{q: %{name_contains: "Test"}}), expected)
   end
 
   test "handles different default primary key" do
-    query = from n in Test.Noid, preload: []
-    expected = from n in Test.Noid, order_by: [desc: n.name]
-    assert_equal ExQueb.build_order_bys(query, %{all: [preload: []]}, :index, [resource: "noids"]), expected
+    query = from(n in Test.Noid, preload: [])
+    expected = from(n in Test.Noid, order_by: [desc: n.name])
+
+    assert_equal(
+      ExQueb.build_order_bys(query, %{all: [preload: []]}, :index, resource: "noids"),
+      expected
+    )
   end
 
   test "handles no primary key" do
-    expected = from n in Test.Noprimary, order_by: [desc: n.index]
-    query = from n in Test.Noprimary, preload: []
+    expected = from(n in Test.Noprimary, order_by: [desc: n.index])
+    query = from(n in Test.Noprimary, preload: [])
     opts = %{all: [preload: []]}
-    assert_equal ExQueb.build_order_bys(query, opts, :index, [resource: "noprimarys"]), expected
+    assert_equal(ExQueb.build_order_bys(query, opts, :index, resource: "noprimarys"), expected)
   end
 
   test "handles default sort defined in opts" do
-    expected = from n in Test.Noprimary, order_by: [asc: n.name]
-    query = from n in Test.Noprimary, preload: []
+    expected = from(n in Test.Noprimary, order_by: [asc: n.name])
+    query = from(n in Test.Noprimary, preload: [])
     opts = %{all: [preload: []], index: [default_sort: [asc: :name]]}
-    assert_equal ExQueb.build_order_bys(query, opts, :index, [resource: "noprimarys"]), expected
+    assert_equal(ExQueb.build_order_bys(query, opts, :index, resource: "noprimarys"), expected)
   end
 
   test "handles default_sort_order only for primary key id" do
     opts = %{all: [preload: []], index: [default_sort_order: :asc]}
-    query = from n in Test.Model, preload: []
-    expected = from n in Test.Model, order_by: [asc: n.id]
-    assert_equal ExQueb.build_order_bys(query, opts, :index, [resource: "models"]), expected
+    query = from(n in Test.Model, preload: [])
+    expected = from(n in Test.Model, order_by: [asc: n.id])
+    assert_equal(ExQueb.build_order_bys(query, opts, :index, resource: "models"), expected)
   end
 
   test "handles default_sort_field only for no primary key" do
     opts = %{all: [preload: []], index: [default_sort_field: :name]}
-    query = from n in Test.Noprimary, preload: []
-    expected = from n in Test.Noprimary, order_by: [desc: n.name]
-    assert_equal ExQueb.build_order_bys(query, opts, :index, [resource: "noprimarys"]), expected
+    query = from(n in Test.Noprimary, preload: [])
+    expected = from(n in Test.Noprimary, order_by: [desc: n.name])
+    assert_equal(ExQueb.build_order_bys(query, opts, :index, resource: "noprimarys"), expected)
   end
 
   test "string filter contains" do
     expected = where(Test.Model, [m], like(fragment("LOWER(?)", m.name), ^"%test%"))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_contains: "Test"}}), expected
+    assert_equal(ExQueb.filter(Test.Model, %{q: %{name_contains: "Test"}}), expected)
   end
 
   test "string filter begins with" do
     expected = where(Test.Model, [m], like(fragment("LOWER(?)", m.name), ^"test%"))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_begins_with: "Test"}}), expected
+    assert_equal(ExQueb.filter(Test.Model, %{q: %{name_begins_with: "Test"}}), expected)
   end
 
   test "string filter ends with" do
     expected = where(Test.Model, [m], like(fragment("LOWER(?)", m.name), ^"%test"))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_ends_with: "Test"}}), expected
+    assert_equal(ExQueb.filter(Test.Model, %{q: %{name_ends_with: "Test"}}), expected)
   end
 
   test "string filter equals" do
-    expected = where(Test.Model, [m], fragment("LOWER(?)", m.name) == fragment("LOWER(?)", ^"Test"))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_equals: "Test"}}), expected
+    expected =
+      where(Test.Model, [m], fragment("LOWER(?)", m.name) == fragment("LOWER(?)", ^"Test"))
+
+    assert_equal(ExQueb.filter(Test.Model, %{q: %{name_equals: "Test"}}), expected)
   end
 
   def assert_equal(a, b) do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
-
 ExUnit.start()


### PR DESCRIPTION
Hello!

We've been using this pack of fixes for almost a year now and had no problems with it.

It also includes a `mix format`, which could be removed easily, but I think it makes sense to follow `mix format` these days.

The [actual changeset](https://github.com/E-MetroTel/ex_queb/commit/a0f30dbfac9711b7c433d0e867f9faf1a8d0c4c0) with fixes for Ecto 3  changes 8 lines.