### PR TITLE
Added `is_null`, `is_not_null` and `in` possible queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.6"
+
+services:
+  app:
+    image: "elixir:1.8.0"
+    working_dir: /ex_queb
+    stdin_open: true
+    tty: true
+    volumes:
+      - ".:/ex_queb"

--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -70,7 +70,8 @@ defmodule ExQueb do
     where(query, [q], field(q, ^fld) > ^value)
   end
   defp _build_integer_filter(query, fld, value, :in) do
-    where(query, [q], field(q, ^fld) in ^value)
+    value_list = value |> String.split(",") |> Enum.map(&String.trim/1) |> Enum.map(&String.to_integer/1)
+    where(query, [q], field(q, ^fld) in ^value_list)
   end
 
   defp build_date_filters(builder, filters, condition) do

--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -90,29 +90,29 @@ defmodule ExQueb do
   end
 
   defp _build_boolean_filter(query, fld, "not_null", :is) do
-    case ExQueb.Utils.get_entry_type(query, fld) do
-      :field ->
-        where(query, [q], not is_nil(field(q, ^fld)))
+    case IO.inspect(ExQueb.Utils.get_entry_type(query, fld)) do
       :assoc ->
         from(
           m in query,
           as: :query,
           where: exists(ExQueb.Utils.build_exists_subquery(query, fld, :query))
         )
+      :field ->
+        where(query, [q], not is_nil(field(q, ^fld)))
       nil -> query
     end
   end
 
   defp _build_boolean_filter(query, fld, "null", :is) do
     case ExQueb.Utils.get_entry_type(query, fld) do
-      :field ->
-        where(query, [q], is_nil(field(q, ^fld)))
       :assoc ->
         from(
           m in query,
           as: :query,
           where: not exists(ExQueb.Utils.build_exists_subquery(query, fld, :query))
         )
+      :field ->
+        where(query, [q], is_nil(field(q, ^fld)))
       nil -> query
     end
   end

--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -88,11 +88,11 @@ defmodule ExQueb do
     map_filters(builder, filters, condition, &_build_boolean_filter/4)
   end
 
-  defp _build_boolean_filter(query, fld, :not_null, :is) do
+  defp _build_boolean_filter(query, fld, "not_null", :is) do
     where(query, [q], not is_nil(field(q, ^fld)))
   end
 
-  defp _build_boolean_filter(query, fld, :null, :is) do
+  defp _build_boolean_filter(query, fld, "null", :is) do
     where(query, [q], is_nil(field(q, ^fld)))
   end
 

--- a/lib/ex_queb.ex
+++ b/lib/ex_queb.ex
@@ -90,7 +90,7 @@ defmodule ExQueb do
   end
 
   defp _build_boolean_filter(query, fld, "not_null", :is) do
-    case IO.inspect(ExQueb.Utils.get_entry_type(query, fld)) do
+    case ExQueb.Utils.get_entry_type(query, fld) do
       :assoc ->
         from(
           m in query,

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -24,7 +24,8 @@ defmodule ExQueb.Utils do
       %Ecto.Association.ManyToMany{
         queryable: association,
         join_through: join_through,
-        join_keys: [{through_owner_key, owner_key}, {through_assoc_key, assoc_key}]
+        join_keys: [{through_owner_key, owner_key}, {through_assoc_key, assoc_key}],
+        where: where
       } ->
         from(a in association,
           join: jt in ^join_through,
@@ -32,15 +33,18 @@ defmodule ExQueb.Utils do
             field(a, ^assoc_key) == field(jt, ^through_assoc_key) and
             field(jt, ^through_owner_key) == field(parent_as(:query), ^owner_key)
         )
+        |> Ecto.Association.combine_assoc_query(where)
       %type{
         queryable: association,
         related_key: related_key,
-        owner_key: owner_key
+        owner_key: owner_key,
       } when type in [Ecto.Association.Has, Ecto.Association.BelongsTo] ->
+        where: where
         from(
           a in association,
           where: field(a, ^related_key) == field(parent_as(:query), ^owner_key)
         )
+        |> Ecto.Association.combine_assoc_query(where)
     end
   end
 

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,6 +1,15 @@
 defmodule ExQueb.Utils do
   import Ecto.Query
 
+  def get_entry_type(query, entry) do
+    module = query_to_module(query)
+    cond do
+      module.__schema__(:type, entry) -> :field
+      module.__schema__(:association, entry) -> :assoc
+      true -> nil
+    end
+  end
+
   def query_to_module(%Ecto.Query{from: %{source: {_table_name, module}}}) do
     module
   end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,0 +1,28 @@
+defmodule ExQueb.Utils do
+  import Ecto.Query
+
+  def query_to_module(%Ecto.Query{from: %{source: {_table_name, module}}}) do
+    module
+  end
+
+  def query_to_module(other), do: query_to_module(from(q in other))
+
+  def get_assoc_data(query, assoc) do
+    case query_to_module(query).__schema__(:association, assoc) do
+      %{
+        queryable: queryable,
+        related_key: related_key,
+        owner_key: owner_key
+      } -> {queryable, owner_key, related_key}
+    end
+  end
+
+  # Warn: as param is not used, and is set statically to the :query value.
+  # TODO: fix this
+  # See: https://github.com/elixir-ecto/ecto/pull/3465#issuecomment-826796922
+  def build_exists_subquery(query, assoc, _as) do
+    {assoc_struct, owner_key, foreign_key} = get_assoc_data(query, assoc)
+    from(a in assoc_struct, where: field(a, ^foreign_key) == field(parent_as(:query), ^owner_key))
+  end
+
+end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -16,22 +16,32 @@ defmodule ExQueb.Utils do
 
   def query_to_module(other), do: query_to_module(from(q in other))
 
-  def get_assoc_data(query, assoc) do
-    case query_to_module(query).__schema__(:association, assoc) do
-      %{
-        queryable: queryable,
-        related_key: related_key,
-        owner_key: owner_key
-      } -> {queryable, owner_key, related_key}
-    end
-  end
-
   # Warn: as param is not used, and is set statically to the :query value.
   # TODO: fix this
   # See: https://github.com/elixir-ecto/ecto/pull/3465#issuecomment-826796922
   def build_exists_subquery(query, assoc, _as) do
-    {assoc_struct, owner_key, foreign_key} = get_assoc_data(query, assoc)
-    from(a in assoc_struct, where: field(a, ^foreign_key) == field(parent_as(:query), ^owner_key))
+    case query_to_module(query).__schema__(:association, assoc) do
+      %Ecto.Association.ManyToMany{
+        queryable: association,
+        join_through: join_through,
+        join_keys: [{through_owner_key, owner_key}, {through_assoc_key, assoc_key}]
+      } ->
+        from(a in association,
+          join: jt in ^join_through,
+          on:
+            field(a, ^assoc_key) == field(jt, ^through_assoc_key) and
+            field(jt, ^through_owner_key) == field(parent_as(:query), ^owner_key)
+        )
+      %type{
+        queryable: association,
+        related_key: related_key,
+        owner_key: owner_key
+      } when type in [Ecto.Association.Has, Ecto.Association.BelongsTo] ->
+        from(
+          a in association,
+          where: field(a, ^related_key) == field(parent_as(:query), ^owner_key)
+        )
+    end
   end
 
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -4,8 +4,8 @@ defmodule ExQueb.Utils do
   def get_entry_type(query, entry) do
     module = query_to_module(query)
     cond do
-      module.__schema__(:type, entry) -> :field
       module.__schema__(:association, entry) -> :assoc
+      module.__schema__(:type, entry) -> :field
       true -> nil
     end
   end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -38,8 +38,8 @@ defmodule ExQueb.Utils do
         queryable: association,
         related_key: related_key,
         owner_key: owner_key,
-      } when type in [Ecto.Association.Has, Ecto.Association.BelongsTo] ->
         where: where
+      } when type in [Ecto.Association.Has, Ecto.Association.BelongsTo] ->
         from(
           a in association,
           where: field(a, ^related_key) == field(parent_as(:query), ^owner_key)

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExQueb.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 2.0"},
+      {:ecto, "~> 3.3"},
       {:ex_doc, "~> 0.18.0", only: :dev},
       {:earmark, "~> 1.1", only: :dev},
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExQueb.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.1-avril"
 
   def project do
     [app: :ex_queb,

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule ExQueb.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 3.3"},
+      {:ecto, "~> 3.6.1"},
       {:ex_doc, "~> 0.18.0", only: :dev},
       {:earmark, "~> 1.1", only: :dev},
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
-  "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "3.3.2", "002aa428c752a8ee4bb65baa9d1041f0514d7435d2e21d58cb6aa69a1076721d", [:mix], [{:decimal, "~> 1.6 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "decimal": {:hex, :decimal, "2.0.0", "a78296e617b0f5dd4c6caf57c714431347912ffb1d0842e998e9792b5642d697", [:mix], [], "hexpm", "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "ecto": {:hex, :ecto, "3.6.1", "7bb317e3fd0179ad725069fd0fe8a28ebe48fec6282e964ea502e4deccb0bd0f", [:mix], [{:decimal, "~> 1.6 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "cbb3294a990447b19f0725488a749f8cf806374e0d9d0dffc45d61e7aeaf6553"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "9dbe1ce1d711dc5362e3b3280e92989ad61413ce423bc4e9f76d5fcc51ab8d6b"},
+  "telemetry": {:hex, :telemetry, "0.4.3", "a06428a514bdbc63293cd9a6263aad00ddeb66f608163bdec7c8995784080818", [:rebar3], [], "hexpm", "eb72b8365ffda5bed68a620d1da88525e326cb82a75ee61354fc24b844768041"},
 }

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,6 @@
 %{
-  "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ecto": {:hex, :ecto, "2.1.1", "fa8bdb14be9992b777036e20f183b8c4300cc012a0fae748529ff89b5423f2dd", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
+  "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
+  "ecto": {:hex, :ecto, "3.3.2", "002aa428c752a8ee4bb65baa9d1041f0514d7435d2e21d58cb6aa69a1076721d", [:mix], [{:decimal, "~> 1.6 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -165,6 +165,18 @@ defmodule ExQuebTest do
     assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: "null"}}), expected
   end
 
+  test "date filter lower or equal than" do
+    date = Date.utc_today
+    expected = where(Test.Model, [m], m.inserted_at <= ^NaiveDateTime.from_iso8601!("#{Date.to_string(date)} 23:59:59"))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{inserted_at_lte: Date.to_string(date)}}), expected
+  end
+
+  test "date filter greater or equal than" do
+    date = Date.utc_today
+    expected = where(Test.Model, [m], m.inserted_at >= ^NaiveDateTime.from_iso8601!("#{Date.to_string(date)} 00:00:00"))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{inserted_at_gte: Date.to_string(date)}}), expected
+  end
+
   test "embed filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.embed))
     assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: "not_null"}}), expected

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -137,32 +137,32 @@ defmodule ExQuebTest do
 
   test "string filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.name))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is_not_null: nil}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is: :not_null}}), expected
   end
 
   test "string filter is null" do
     expected = where(Test.Model, [m], is_nil(m.name))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is_null: nil}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is: :null}}), expected
   end
 
   test "integer filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.age))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is_not_null: nil}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: :not_null}}), expected
   end
 
   test "integer filter is null" do
     expected = where(Test.Model, [m], is_nil(m.age))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is_null: nil}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: :null}}), expected
   end
 
   test "embed filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.embed))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is_not_null: nil}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: :not_null}}), expected
   end
 
   test "embed filter is null" do
     expected = where(Test.Model, [m], is_nil(m.embed))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is_null: nil}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: :null}}), expected
   end
 
   def assert_equal(a, b) do

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -208,7 +208,7 @@ defmodule ExQuebTest do
       as: :query,
       where: not exists(from(a in Test.Children, where: a.model_id == parent_as(:query).id))
     )
-    assert_equal ExQueb.filter(Test.Model, %{q: %{children_is: "not_exists"}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{children_is: "null"}}), expected
   end
 
   test "children assoc filter exists" do
@@ -217,7 +217,7 @@ defmodule ExQuebTest do
       as: :query,
       where: exists(from(a in Test.Children, where: a.model_id == parent_as(:query).id))
     )
-    assert_equal ExQueb.filter(Test.Model, %{q: %{children_is: "exists"}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{children_is: "not_null"}}), expected
   end
 
   test "parent assoc filter not exists" do
@@ -226,7 +226,7 @@ defmodule ExQuebTest do
       as: :query,
       where: not exists(from(a in Test.Parent, where: a.id == parent_as(:query).parent_id))
     )
-    assert_equal ExQueb.filter(Test.Model, %{q: %{parent_is: "not_exists"}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{parent_is: "null"}}), expected
   end
 
   test "parent assoc filter exists" do
@@ -235,7 +235,7 @@ defmodule ExQuebTest do
       as: :query,
       where: exists(from(a in Test.Parent, where: a.id == parent_as(:query).parent_id))
     )
-    assert_equal ExQueb.filter(Test.Model, %{q: %{parent_is: "exists"}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{parent_is: "not_null"}}), expected
   end
 
   def assert_equal(a, b) do

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -137,32 +137,32 @@ defmodule ExQuebTest do
 
   test "string filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.name))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is: :not_null}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is: "not_null"}}), expected
   end
 
   test "string filter is null" do
     expected = where(Test.Model, [m], is_nil(m.name))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is: :null}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is: "null"}}), expected
   end
 
   test "integer filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.age))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: :not_null}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: "not_null"}}), expected
   end
 
   test "integer filter is null" do
     expected = where(Test.Model, [m], is_nil(m.age))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: :null}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is: "null"}}), expected
   end
 
   test "embed filter is not null" do
     expected = where(Test.Model, [m], not is_nil(m.embed))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: :not_null}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: "not_null"}}), expected
   end
 
   test "embed filter is null" do
     expected = where(Test.Model, [m], is_nil(m.embed))
-    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: :null}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is: "null"}}), expected
   end
 
   def assert_equal(a, b) do

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -3,6 +3,16 @@ defmodule Test.Model do
   schema "models" do
     field :name, :string
     field :age, :integer
+    embeds_one(:embed, Test.Embed)
+
+    timestamps()
+  end
+end
+
+defmodule Test.Embed do
+  use Ecto.Schema
+  schema "models" do
+    field :name, :string
 
     timestamps()
   end
@@ -98,6 +108,41 @@ defmodule ExQuebTest do
   test "string filter equals" do
     expected = where(Test.Model, [m], fragment("LOWER(?)", m.name) == fragment("LOWER(?)", ^"Test"))
     assert_equal ExQueb.filter(Test.Model, %{q: %{name_equals: "Test"}}), expected
+  end
+
+  test "string filter equals nil" do
+    expected = Test.Model
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_equals: nil}}), expected
+  end
+
+  test "string filter is not null" do
+    expected = where(Test.Model, [m], not is_nil(m.name))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is_not_null: nil}}), expected
+  end
+
+  test "string filter is null" do
+    expected = where(Test.Model, [m], is_nil(m.name))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{name_is_null: nil}}), expected
+  end
+
+  test "integer filter is not null" do
+    expected = where(Test.Model, [m], not is_nil(m.age))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is_not_null: nil}}), expected
+  end
+
+  test "integer filter is null" do
+    expected = where(Test.Model, [m], is_nil(m.age))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_is_null: nil}}), expected
+  end
+
+  test "embed filter is not null" do
+    expected = where(Test.Model, [m], not is_nil(m.embed))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is_not_null: nil}}), expected
+  end
+
+  test "embed filter is null" do
+    expected = where(Test.Model, [m], is_nil(m.embed))
+    assert_equal ExQueb.filter(Test.Model, %{q: %{embed_is_null: nil}}), expected
   end
 
   def assert_equal(a, b) do

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -90,6 +90,26 @@ defmodule ExQuebTest do
     assert_equal ExQueb.build_order_bys(query, opts, :index, [resource: "noprimarys"]), expected
   end
 
+  test "integer filter greater than" do
+    expected = where(Test.Model, [m], m.age > ^10)
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_gt: 10}}), expected
+  end
+
+  test "integer filter lower than" do
+    expected = where(Test.Model, [m], m.age < ^10)
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_lt: 10}}), expected
+  end
+
+  test "integer filter lower than nil" do
+    expected = Test.Model
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_lt: nil}}), expected
+  end
+
+  test "integer filter in list" do
+    expected = where(Test.Model, [m], m.age in ^[10, 11, 12])
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_in: [10, 11, 12]}}), expected
+  end
+
   test "string filter contains" do
     expected = where(Test.Model, [m], like(fragment("LOWER(?)", m.name), ^"%test%"))
     assert_equal ExQueb.filter(Test.Model, %{q: %{name_contains: "Test"}}), expected

--- a/test/ex_queb_test.exs
+++ b/test/ex_queb_test.exs
@@ -105,9 +105,19 @@ defmodule ExQuebTest do
     assert_equal ExQueb.filter(Test.Model, %{q: %{age_lt: nil}}), expected
   end
 
+  test "integer filter in single element list" do
+    expected = where(Test.Model, [m], m.age in ^[10])
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_in: "10"}}), expected
+  end
+
   test "integer filter in list" do
     expected = where(Test.Model, [m], m.age in ^[10, 11, 12])
-    assert_equal ExQueb.filter(Test.Model, %{q: %{age_in: [10, 11, 12]}}), expected
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_in: "10,11,12"}}), expected
+  end
+
+  test "integer filter in list with spaces" do
+    expected = where(Test.Model, [m], m.age in ^[10, 11, 12])
+    assert_equal ExQueb.filter(Test.Model, %{q: %{age_in: "10, 11 , 12"}}), expected
   end
 
   test "string filter contains" do


### PR DESCRIPTION
I'm aware all those repos are unmaintained, but in case it interests someone, I added the possibility to:

- `q[whatever_field_is_not_null]`
- `q[whatever_field_is_null]`
- `q[integer_field_in]=[1, 2, 3]`

Hopefully this can help some people.

Since it is 100% backward compatible and tests are covered, on shall consider merging I reckon.